### PR TITLE
Avoid complet twice

### DIFF
--- a/lib/src/whois_base.dart
+++ b/lib/src/whois_base.dart
@@ -111,6 +111,7 @@ class Whois {
     socket.listen(
       // Handle data from the server
       (Uint8List data) {
+        if (completer.isCompleted) return;
         final serverResponse = String.fromCharCodes(data);
         completer.complete(serverResponse);
       },


### PR DESCRIPTION
If you complete() twice then get these exception:

```
Unhandled exception:
Bad state: Future already completed
#0      _AsyncCompleter.complete (dart:async/future_impl.dart:43:31)
```
